### PR TITLE
Add layout.conf file to please egencache

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,0 +1,2 @@
+masters = gentoo
+


### PR DESCRIPTION
Without it, a warning is emitted at repo sync time:

```
!!! Repository 'aclex-pytorch' is missing masters attribute in '/var/db/repos/aclex-pytorch/metadata/layout.conf'
!!! Set 'masters = gentoo' in this file for future compatibility
```