### PR TITLE
Add missing OpenCL dependency

### DIFF
--- a/sci-libs/pytorch/pytorch-1.3.0.ebuild
+++ b/sci-libs/pytorch/pytorch-1.3.0.ebuild
@@ -50,7 +50,7 @@ DEPEND="
 	mpi? ( virtual/mpi )
 	numpy? ( dev-python/numpy )
 	openblas? ( sci-libs/openblas )
-	opencl? ( virtual/opencl )
+	opencl? ( dev-libs/clhpp virtual/opencl )
 	opencv? ( media-libs/opencv )
 	python? ( ${PYTHON_DEPS} )
 	redis? ( dev-db/redis )

--- a/sci-libs/pytorch/pytorch-1.3.1.ebuild
+++ b/sci-libs/pytorch/pytorch-1.3.1.ebuild
@@ -50,7 +50,7 @@ DEPEND="
 	mpi? ( virtual/mpi )
 	numpy? ( dev-python/numpy )
 	openblas? ( sci-libs/openblas )
-	opencl? ( virtual/opencl )
+	opencl? ( dev-libs/clhpp virtual/opencl )
 	opencv? ( media-libs/opencv )
 	python? ( ${PYTHON_DEPS} )
 	redis? ( dev-db/redis )


### PR DESCRIPTION
Without the `dev-libs/clhpp` package, with `USE='opencl'`, compilation
fails with:

```
In file included from /path/to/sci-libs/pytorch-1.3.1/work/pytorch-1.3.1/caffe2/contrib/opencl/context.cc:1:
/path/to/sci-libs/pytorch-1.3.1/work/pytorch-1.3.1/caffe2/contrib/opencl/context.h:14:10: fatal error: CL/cl.hpp: No such file or directory
   14 | #include <CL/cl.hpp>
      |          ^~~~~~~~~~~
compilation terminated.
```

Note that as two ebuild files changed, the `Manifest` file needs to be
recomputed, and is *not* included in this patch to avoid conflict with
the `master` branch (The `missing-manifests` pull request should be
applied first, then this very pull request, then the `Manifest` for
`sci-libs/pytorch` should be rebuilt and committed).