### PR TITLE
Add missing repo_name

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,0 +1,1 @@
+aclex-pytorch


### PR DESCRIPTION
Without it, emerge spits out a warning:

```
WARNING: One or more repositories have missing repo_name entries:

        /var/db/repos/aclex-pytorch/profiles/repo_name

NOTE: Each repo_name entry should be a plain text file containing a
unique name for the repository on the first line.
```

Even though the `README.md` file suggests any name would work, it'd be
easier maintenance to force the suggested name so that `repo_name`
matches and `emerge` stops complaining.