### PR TITLE
Match local rocm repository name with upstream.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Probably the easiest way to register external portage repository in the system i
 
 ```bash
 cat >> /etc/portage/repos.conf/justxi-rocm.conf << EOF
-[justxi-rocm]
+[rocm]
 location = /var/db/repos/justxi-rocm
 sync-type = git
 sync-uri = https://github.com/justxi/rocm


### PR DESCRIPTION
Without this change, portage complains when doing a sync:

```
!!! Section 'justxi-rocm' in repos.conf has name different from
repository name 'rocm' set inside repository
```