### PR TITLE
fixed cuda access violation error

### DIFF
--- a/sci-libs/torchvision/torchvision-0.8.2.ebuild
+++ b/sci-libs/torchvision/torchvision-0.8.2.ebuild
@@ -55,6 +55,7 @@ src_compile() {
 	cmake_src_compile
 
 	if use python; then
+		addpredict /dev/nvidiactl
 		FORCE_CUDA=$(usex cuda 1 0) \
 		CUDA_HOME=$(usex cuda ${CUDA_HOME} "") \
 		NO_FFMPEG=$(usex ffmpeg 0 1) \


### PR DESCRIPTION
without this fix I am getting an access violation error when emerging torchvision with the cuda use flag: [build.log](https://github.com/aclex/pytorch-ebuild/files/6025203/build.log)
